### PR TITLE
add deployed contract to .env, simplify README flow

### DIFF
--- a/.env
+++ b/.env
@@ -2,7 +2,7 @@
 # Set to target the Sepolia deployment, from https://docs.beboundless.xyz/deployments
 RPC_URL="https://ethereum-sepolia-rpc.publicnode.com"
 ORDER_STREAM_URL="https://order-stream.beboundless.xyz"
-
 SET_VERIFIER_ADDRESS="0xEf0A93B2310d52358F1eCA0C946aD7D25596e7dd"
 VERIFIER_ROUTER_ADDRESS="0x925d8331ddc0a1F0d96E68CF073DFE1d92b69187"
 BOUNDLESS_MARKET_ADDRESS="0x69c7943DA0D7e45D44Bd0cE7a2412DCdAe423788"
+EVEN_NUMBER_ADDRESS="0x29340e3f2264d3dAB1c89328b1AbbcE756e2aD5B"

--- a/README.md
+++ b/README.md
@@ -1,9 +1,44 @@
 # Boundless Foundry Template
 
-This template serves as a starting point for developing an application with verifiable compute provided by [Boundless][boundless-homepage].
-It is built around a simple smart contract, `EvenNumber`, and its associated RISC Zero guest, `is-even`.
+This template serves as a starter app powered by verifiable compute from [Boundless](https://docs.beboundless.xyz). It is built around a simple smart contract, `EvenNumber` deployed on Sepolia, and its associated RISC Zero guest, `is-even`.
 
-## Build
+## Set up your environment variables
+
+Export your Sepolia wallet private key as an environment variable (making sure it has enough funds):
+
+```bash
+export WALLET_PRIVATE_KEY="YOUR_WALLET_PRIVATE_KEY"
+```
+
+To allow provers to access your zkVM guest binary, it must be uploaded to a public URL. For this example we will upload to IPFS using Pinata. Pinata has a free tier with plenty of quota to get started. Sign up at [[Pinata](https://pinata.cloud/)](https://pinata.cloud/), generate an API key, and set the JWT as an environment variable:
+
+```bash
+export PINATA_JWT="YOUR_PINATA_JWT"
+```
+
+To load the rest of the environment variables (i.e. Boundless contract deployments), run:
+
+```bash
+. ./.env
+```
+
+> If you'd like to deploy your own version of the `EvenNumber.sol` contract, please run:
+> `forge script contracts/scripts/Deploy.s.sol --rpc-url ${RPC_URL:?} --broadcast -vv`
+> and save the deployed contract address to the .env file.
+
+## Run the example app
+
+The [example app](apps/src/main.rs) will upload your zkVM guest to IPFS, submit a request to the market for a proof that "4" is an even number, wait for the request to be fulfilled, and then submit that proof to the EvenNumber contract, setting the value to "4".
+
+To run the example:
+
+```bash
+RUST_LOG=info cargo run --bin app -- --even-number-address ${EVEN_NUMBER_ADDRESS:?} --number 4
+```
+
+## Local Development 
+
+### Build
 
 To build the example run:
 
@@ -14,7 +49,7 @@ cargo build
 forge build
 ```
 
-## Test
+### Test
 
 Test the Solidity smart contracts with:
 
@@ -28,60 +63,4 @@ Test the Rust code including the guest with:
 cargo test
 ```
 
-## Deploy to Testnet
 
-### Set up your environment
-
-Export your Sepolia testnet wallet private key as an environment variable:
-
-```bash
-export WALLET_PRIVATE_KEY="YOUR_WALLET_PRIVATE_KEY"
-```
-
-To allow provers to access your zkVM guest binary, it must be uploaded to a public URL. For this example we will upload to IPFS using Pinata. Pinata has a free tier with plenty of quota to get started. Sign up at [[Pinata](https://pinata.cloud/)](https://pinata.cloud/), generate an API key, and set the JWT as an environment variable:
-
-```bash
-export PINATA_JWT="YOUR_PINATA_JWT"
-```
-
-A [`.env`](./.env) file is provided with the Boundless contract deployment information for Sepolia.
-The example app reads from this `.env` file automatically.
-
-### Deploy the contract
-
-To deploy the `EvenNumber` contract run:
-
-```bash
-. ./.env # load the environment variables from the .env file for deployment
-forge script contracts/scripts/Deploy.s.sol --rpc-url ${RPC_URL:?} --broadcast -vv
-```
-
-Save the `EvenNumber` contract address to an env variable:
-
-<!-- TODO: Update me -->
-
-```bash
-# First contract deployed and top of logs is EvenNumber
-export EVEN_NUMBER_ADDRESS=#COPY EVEN NUMBER ADDRESS FROM DEPLOY LOGS
-```
-
-> You can also use the following command to set the contract address if you have [`jq`][jq] installed:
->
-> ```bash
-> export EVEN_NUMBER_ADDRESS=$(jq -re '.transactions[] | select(.contractName == "EvenNumber") | .contractAddress' ./broadcast/Deploy.s.sol/11155111/run-latest.json)
-> ```
-
-### Run the example
-
-The [example app](apps/src/main.rs) will upload your zkVM guest to IPFS, submit a request to the market for a proof that "4" is an even number, wait for the request to be fulfilled, and then submit that proof to the EvenNumber contract, setting the value to "4".
-
-
-To run the example:
-
-```bash
-RUST_LOG=info cargo run --bin app -- --even-number-address ${EVEN_NUMBER_ADDRESS:?} --number 4
-```
-
-[jq]: https://jqlang.github.io/jq/
-[boundless-homepage]: https://beboundless.xyz
-[sepolia]: https://ethereum.org/en/developers/docs/networks/#sepolia


### PR DESCRIPTION
* to simplify one step, I've deployed the EvenNumber contract to Sepolia and added the address to the .env.
* reflecting this, I've prioritised the running of the Boundless foundry template to the top of the README and simplified the flow by removing the deploy step (but still leaving a notice in case the reader does want to deploy their own version). 