### PR TITLE
fix broken beboundless link in .env

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,5 @@
 # Environment variables read by the example app.
-# Set to target the Sepolia deployment, from https://docs.beboundless.xyz/deployments
+# Set to target the Sepolia deployment, from https://docs.beboundless.xyz/developers/smart-contracts/deployments#deployments
 RPC_URL="https://ethereum-sepolia-rpc.publicnode.com"
 ORDER_STREAM_URL="https://eth-sepolia.beboundless.xyz/"
 


### PR DESCRIPTION
Hey team—noticed a dead link, replaced it with a working URL

https://docs.beboundless.xyz/deployments - broken link
https://docs.beboundless.xyz/developers/smart-contracts/deployments#deployments - new link