### PR TITLE
BM-978: make PK env consistent with boundless monorepo examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This template serves as a starter app powered by verifiable compute from [Boundl
 Export your Sepolia wallet private key as an environment variable (making sure it has enough funds):
 
 ```bash
-export WALLET_PRIVATE_KEY="YOUR_WALLET_PRIVATE_KEY"
+export PRIVATE_KEY="YOUR_PRIVATE_KEY"
 ```
 
 For provers to access the zkVM guest ELF binary, it must be uploaded to IPFS. This example uses [Pinata](https://pinata.cloud/). Pinata has a free tier with plenty of quota to get started. Create an account, generate an API key, and set the JWT as an environment variable:

--- a/apps/src/main.rs
+++ b/apps/src/main.rs
@@ -54,7 +54,7 @@ struct Args {
     rpc_url: Url,
     /// Private key used to interact with the EvenNumber contract.
     #[clap(short, long, env)]
-    wallet_private_key: PrivateKeySigner,
+    private_key: PrivateKeySigner,
     /// Submit the request offchain via the provided order stream service url.
     #[clap(short, long, requires = "order_stream_url")]
     offchain: bool,
@@ -96,7 +96,7 @@ async fn main() -> Result<()> {
         .with_order_stream_url(args.offchain.then_some(args.order_stream_url).flatten())
         .with_storage_provider_config(args.storage_config)
         .await?
-        .with_private_key(args.wallet_private_key)
+        .with_private_key(args.private_key)
         .build()
         .await?;
 

--- a/contracts/scripts/Deploy.s.sol
+++ b/contracts/scripts/Deploy.s.sol
@@ -21,7 +21,7 @@ import {EvenNumber} from "../src/EvenNumber.sol";
 contract Deploy is Script {
     function run() external {
         // load ENV variables first
-        uint256 key = vm.envUint("WALLET_PRIVATE_KEY");
+        uint256 key = vm.envUint("PRIVATE_KEY");
         address verifierAddress = vm.envAddress("VERIFIER_ROUTER_ADDRESS");
         vm.startBroadcast(key);
 


### PR DESCRIPTION
I noticed that examples in the Boundless monorepo use the env var: `PRIVATE_KEY` whilst here it is `WALLET_PRIVATE_KEY`, so I updated it here to make it consistent across the examples + foundry template.