### PR TITLE
Enhance EvenNumber contract with event tracking and interface implementation

### DIFF
--- a/contracts/src/EvenNumber.sol
+++ b/contracts/src/EvenNumber.sol
@@ -16,12 +16,13 @@ pragma solidity ^0.8.20;
 
 import {IRiscZeroVerifier} from "risc0/IRiscZeroVerifier.sol";
 import {ImageID} from "./ImageID.sol"; // auto-generated contract after running `cargo build`.
+import {IEvenNumber} from "./IEvenNumber.sol";
 
 /// @title A starter application using RISC Zero.
 /// @notice This basic application holds a number, guaranteed to be even.
 /// @dev This contract demonstrates one pattern for offloading the computation of an expensive
 ///      or difficult to implement function to a RISC Zero guest.
-contract EvenNumber {
+contract EvenNumber is IEvenNumber {
     /// @notice RISC Zero verifier contract address.
     IRiscZeroVerifier public immutable verifier;
     /// @notice Image ID of the only zkVM binary to accept verification from.
@@ -34,6 +35,11 @@ contract EvenNumber {
     /// @notice A number that is guaranteed, by the RISC Zero zkVM, to be even.
     ///         It can be set by calling the `set` function.
     uint256 public number;
+    
+    /// @notice Event emitted when the number is updated
+    /// @param oldValue The previous value
+    /// @param newValue The new value
+    event NumberUpdated(uint256 oldValue, uint256 newValue);
 
     /// @notice Initialize the contract, binding it to a specified RISC Zero verifier.
     constructor(IRiscZeroVerifier _verifier) {
@@ -46,7 +52,11 @@ contract EvenNumber {
         // Construct the expected journal data. Verify will fail if journal does not match.
         bytes memory journal = abi.encode(x);
         verifier.verify(seal, imageId, sha256(journal));
+        
+        uint256 oldValue = number;
         number = x;
+        
+        emit NumberUpdated(oldValue, x);
     }
 
     /// @notice Returns the number stored.

--- a/contracts/test/EvenNumber.t.sol
+++ b/contracts/test/EvenNumber.t.sol
@@ -56,4 +56,27 @@ contract EvenNumberTest is RiscZeroCheats, Test {
         vm.expectRevert(VerificationFailed.selector);
         evenNumber.set(1, receipt.seal);
     }
+
+    // Test that the NumberUpdated event is emitted with correct values
+    function test_NumberUpdatedEvent() public {
+        uint256 initialNumber = evenNumber.get();
+        uint256 newNumber = 42;
+        RiscZeroReceipt memory receipt = verifier.mockProve(ImageID.IS_EVEN_ID, sha256(abi.encode(newNumber)));
+
+        // Expect the NumberUpdated event with the correct old and new values
+        vm.expectEmit(true, true, true, true);
+        emit EvenNumber.NumberUpdated(initialNumber, newNumber);
+        
+        // Set the new number
+        evenNumber.set(newNumber, receipt.seal);
+        
+        // Update again to test with non-zero initial value
+        uint256 newerNumber = 100;
+        RiscZeroReceipt memory receipt2 = verifier.mockProve(ImageID.IS_EVEN_ID, sha256(abi.encode(newerNumber)));
+        
+        vm.expectEmit(true, true, true, true);
+        emit EvenNumber.NumberUpdated(newNumber, newerNumber);
+        
+        evenNumber.set(newerNumber, receipt2.seal);
+    }
 }


### PR DESCRIPTION
I noticed that while working with the EvenNumber contract, there was no way to track changes to the stored number without constantly polling the contract. This PR adds proper event emission when the number changes, making it much easier to build reactive UIs and track contract activity.

Changes:
- Explicitly implemented the IEvenNumber interface for better type safety
- Added a NumberUpdated event that tracks both old and new values
- Added comprehensive test coverage for the event emission