### PR TITLE
remove reference to non-existent parameter in offchain flag

### DIFF
--- a/apps/src/main.rs
+++ b/apps/src/main.rs
@@ -56,7 +56,7 @@ struct Args {
     #[clap(long, env)]
     program_url: Option<Url>,
     /// Submit the request offchain via the provided order stream service url.
-    #[clap(short, long, requires = "order_stream_url")]
+    #[clap(short, long)]
     offchain: bool,
     /// Configuration for the StorageProvider to use for uploading programs and inputs.
     #[clap(flatten, next_help_heading = "Storage Provider")]


### PR DESCRIPTION
Removes the `requires = "order_stream_url"` directive from the offchain parameter annotation since the referenced parameter doesn't exist in the Args struct. This prevents potential runtime errors when using the --offchain flag.