### PR TITLE
fix: adjust lib dir in foundry manifest and improve docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,12 @@ It is built around a simple smart contract, `EvenNumber` deployed on Sepolia, an
 
 To build the example run:
 
-```
+```bash
+# Install dependencies
+forge install
+# Build Solidity contracts 
 forge build
+# Build guest program and host application
 cargo build
 ```
 

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,7 +1,7 @@
 [profile.default]
 src = "contracts/src"
 out = "contracts/out"
-libs = ["lib", "contracts/src"]
+libs = ["lib"]
 script = "contracts/scripts"
 test = "contracts/test"
 ffi = true


### PR DESCRIPTION
When cloning the template with git (or `forge init --template ...`) `forge` dependencies need to be installed with `forge install`. Due to misconfigured `lib` section in foundry manifest, the risc0 dependencies were not installed in correct location (under `contracts/src`).

e.g.
```
forge install
Updating dependencies in ../boundless-foundry-template/contracts/src
```

This PR addresses this by specifying `lib` directory as the only directly for libs, and improves `README.md` by including `forge install` step for development